### PR TITLE
chore(issue-watcher): skip issues labeled 'blocked'

### DIFF
--- a/web/src/kernel/scheduled/issue-watcher.ts
+++ b/web/src/kernel/scheduled/issue-watcher.ts
@@ -16,10 +16,10 @@ const LABEL_TO_CATEGORY: Record<string, { category: string; authority: 'auto_saf
   refactor:      { category: 'refactor', authority: 'proposed' },
 };
 
-// Labels that signal multi-session scope — these issues are human-driven
-// and should NOT be auto-queued as single-session taskrunner tasks.
-// See aegis-daemon/artifacts/taskrunner-scope-process.md for the scope gate.
-const SKIP_LABELS = new Set(['wishlist', 'roadmap', 'epic']);
+// Labels that signal the issue should NOT be auto-queued as a single-session taskrunner task:
+// - wishlist / roadmap / epic: multi-session, human-driven scope (see aegis-daemon/artifacts/taskrunner-scope-process.md)
+// - blocked: cannot proceed until listed blockers close; operator removes the label when unblocked
+const SKIP_LABELS = new Set(['wishlist', 'roadmap', 'epic', 'blocked']);
 
 function classifyIssue(labels: string[]): { category: string; authority: 'auto_safe' | 'proposed' } | null {
   for (const label of labels) {

--- a/web/tests/issue-watcher.test.ts
+++ b/web/tests/issue-watcher.test.ts
@@ -407,6 +407,18 @@ describe('runIssueWatcher scope label filter', () => {
     expect(insertCalls).toHaveLength(0);
   });
 
+  it('skips issue with blocked label', async () => {
+    const db = createMockDb();
+    const issue = makeIssue({ labels: ['refactor', 'blocked'] });
+    mockListIssues.mockResolvedValueOnce([issue]);
+
+    await runIssueWatcher(makeEnv(db));
+
+    const insertCalls = (db.prepare as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: string[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO cc_tasks'));
+    expect(insertCalls).toHaveLength(0);
+  });
+
   it('skip label filter is case-insensitive', async () => {
     const db = createMockDb();
     const issue = makeIssue({ labels: ['bug', 'WISHLIST'] });


### PR DESCRIPTION
## Summary

Extends \`SKIP_LABELS\` in the scheduled issue-watcher so issues tagged \`blocked\` are not auto-queued as cc_tasks. Paired with a new \`blocked\` label on aegis god-object epic children (aegis#536-542) that have unsatisfied phase-1 dependencies.

## Why

Without this gate, a 2h issue-watcher tick could queue Phase 2/3/4 refactor issues as tasks before the Phase 1 foundations (#533 ExecutorRegistry, #534 MemoryService, #535 EmailBuilder) ship. Downstream refactors depend on those abstractions; running them on the pre-phase-1 codebase would either duplicate the foundation work inside the wrong scope or produce churn that collides with the phase-1 PRs.

\`wishlist\`, \`roadmap\`, \`epic\` were already in \`SKIP_LABELS\` for the same class of reason (multi-session scope). \`blocked\` fits the same pattern: a declarative 'do not queue yet' signal that the operator owns.

## Changes

- \`web/src/kernel/scheduled/issue-watcher.ts\` — \`SKIP_LABELS\` adds \`blocked\`; comment clarifies semantics
- \`web/tests/issue-watcher.test.ts\` — new case: blocked-labeled issue produces zero \`INSERT INTO cc_tasks\`

## Test plan

- [x] \`npx vitest run tests/issue-watcher.test.ts\` — 32/32 pass locally
- [ ] Merge + wait for next issue-watcher tick on aegis-daemon (runs every 2h) — verify #536-542 don't get queued

## Related

- aegis#532 (god-object epic) and its Phase 2+ children #536-542 are labeled \`blocked\` already
- Operator removes the label when blockers close and the child becomes eligible

🤖 Generated with [Claude Code](https://claude.com/claude-code)