### PR TITLE
fix(router): coerce non-string LLM classification responses to string

### DIFF
--- a/web/src/groq.ts
+++ b/web/src/groq.ts
@@ -30,11 +30,16 @@ export async function askGroq(
   }
 
   const data = await response.json<{
-    choices: { message: { content: string } }[];
+    choices: { message: { content: unknown } }[];
     usage?: { total_tokens: number };
   }>();
 
-  return data.choices[0]?.message?.content ?? '';
+  const content = data.choices[0]?.message?.content;
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+  // Some Groq-routed models (notably gpt-oss tool-calling variants) return content
+  // as an array of content blocks. Coerce so downstream string operations don't crash.
+  return typeof content === 'object' ? JSON.stringify(content) : String(content);
 }
 
 // ─── Logprobs-enabled classification ─────────────────────────

--- a/web/src/kernel/router.ts
+++ b/web/src/kernel/router.ts
@@ -79,8 +79,14 @@ async function classifyWithWorkersAI(
     ],
     max_tokens: 200,
     temperature: 0.1,
-  }) as { response?: string };
-  return result.response ?? '';
+  }) as { response?: unknown };
+  const raw = result.response;
+  if (typeof raw === 'string') return raw;
+  if (raw == null) return '';
+  // Workers AI sometimes returns structured responses (objects with tool_calls,
+  // arrays of segments, etc.). Coerce to string so downstream .trim()/JSON.parse
+  // callers don't crash on non-string payloads.
+  return typeof raw === 'object' ? JSON.stringify(raw) : String(raw);
 }
 
 


### PR DESCRIPTION
## Problem

Every `/api/message` call has been crashing with `rawClassification.trim is not a function` since Workers AI and certain Groq-routed models (gpt-oss tool-calling variants) started returning structured content objects/arrays instead of plain strings.

## Root cause

`classifyWithWorkersAI` had `as { response?: string }` cast — TypeScript doesn't enforce at runtime, so when Workers AI returned an object payload it silently slipped through and crashed downstream at `.trim()`.

`askGroq` had the same problem with `message.content` typed as `string` but sometimes returned as an array of content blocks.

## Fix

Both functions now explicitly coerce non-string payloads:
- `string` → pass through
- `null`/`undefined` → empty string
- `object`/`array` → `JSON.stringify()`
- other primitives → `String()`

The empty-string fallback on null is preserved so downstream null checks short-circuit correctly.

## Validation

- Typecheck: clean (`tsc --noEmit` exits 0)
- Found via daemon-side ablation testing — production endpoint was 100% erroring on the chat path

🤖 Generated with [Claude Code](https://claude.com/claude-code)