### PR TITLE
ci(release): migrate to OIDC trusted publishing + provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # required for npm OIDC trusted publishing + provenance attestation
 
 jobs:
   publish:
@@ -35,6 +36,4 @@ jobs:
 
       - name: Publish
         working-directory: web
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Replaces the long-lived `NPM_TOKEN` secret with GitHub OIDC trusted publishing. The publish workflow has been failing because the stored `NPM_TOKEN` expired (last successful publish: 2026-05-08).

## Setup required (one-time, on npmjs.com)

Before merging this PR, configure the trusted publisher:
1. npmjs.com → @stackbilt/aegis-core → Settings → Trusted Publishers
2. Add: GitHub Actions → `Stackbilt-dev/aegis-oss` → workflow `release.yml`

## What this PR does

- Adds `permissions: id-token: write` (required for npm to receive the GitHub OIDC token)
- Removes `NODE_AUTH_TOKEN` env var (OIDC handles auth)
- Adds `--provenance --access public` flags to `npm publish` (ships an SLSA attestation linking the artifact to this commit + workflow run)

## After merge

- Retag v0.6.4 → workflow runs → publishes with provenance, no token needed
- Old `NPM_TOKEN` secret can be deleted from repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)