### PR TITLE
fix(auth): login form for any HTML navigation (unblocks downstream /lite)

### DIFF
--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -31,8 +31,12 @@ export async function bearerAuth(c: Context<{ Bindings: Env }>, next: Next): Pro
   const token = extractBearer(authHeader) ?? cookieToken ?? queryToken;
 
   if (!token || token !== c.env.AEGIS_TOKEN) {
-    // UI pages — show login page
-    if ((c.req.path === '/chat' || c.req.path === '/overworld' || c.req.path === '/console') && c.req.method === 'GET') {
+    // UI pages — show the login form for top-level HTML navigations (a GET
+    // whose Accept includes text/html) so the operator can enter a token.
+    // Path-agnostic on purpose: any page route — core or downstream-variant
+    // (e.g. the daemon's /lite) — gets the form without core enumerating it.
+    // API/fetch requests (Accept */* or application/json) get JSON 401.
+    if (c.req.method === 'GET' && (c.req.header('Accept') ?? '').includes('text/html')) {
       return c.html(loginPage(), 401);
     }
     return c.json({ error: 'Unauthorized' }, 401);

--- a/web/tests/auth.test.ts
+++ b/web/tests/auth.test.ts
@@ -11,8 +11,9 @@ function makeContext(overrides: {
   authHeader?: string;
   cookie?: string;
   queryToken?: string;
+  accept?: string;
 }): Context<{ Bindings: Env }> {
-  const { path, method = 'GET', authHeader, cookie, queryToken } = overrides;
+  const { path, method = 'GET', authHeader, cookie, queryToken, accept } = overrides;
   return {
     req: {
       path,
@@ -20,6 +21,7 @@ function makeContext(overrides: {
       header: (name: string) => {
         if (name === 'Authorization') return authHeader;
         if (name === 'Cookie') return cookie ?? '';
+        if (name === 'Accept') return accept;
         return undefined;
       },
       query: (name: string) => {
@@ -109,11 +111,26 @@ describe('bearerAuth', () => {
       expect(next).not.toHaveBeenCalled();
     });
 
-    it('shows login page for GET /chat without token', async () => {
-      const c = makeContext({ path: '/chat', method: 'GET' });
+    it('shows login page for an HTML navigation (GET /chat, Accept: text/html) without token', async () => {
+      const c = makeContext({ path: '/chat', method: 'GET', accept: 'text/html,application/xhtml+xml' });
       await bearerAuth(c, next);
       expect(next).not.toHaveBeenCalled();
       expect(c.html).toHaveBeenCalledWith(expect.stringContaining('AEGIS'), 401);
+    });
+
+    it('shows login page for any page route navigation (GET /lite, Accept: text/html) — path-agnostic', async () => {
+      const c = makeContext({ path: '/lite', method: 'GET', accept: 'text/html' });
+      await bearerAuth(c, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(c.html).toHaveBeenCalledWith(expect.stringContaining('AEGIS'), 401);
+    });
+
+    it('returns JSON 401 (not the login form) for a fetch/API request without token', async () => {
+      const c = makeContext({ path: '/api/agenda', method: 'GET', accept: '*/*' });
+      await bearerAuth(c, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(c.json).toHaveBeenCalledWith({ error: 'Unauthorized' }, 401);
+      expect(c.html).not.toHaveBeenCalled();
     });
 
     it('prioritizes Authorization header over cookie', async () => {


### PR DESCRIPTION
## Show the login form for any HTML navigation, not a hardcoded page list

`bearerAuth` only rendered the token-entry login form for three hardcoded paths (`/chat`, `/overworld`, `/console`). Any other page route — notably **downstream-variant pages like aegis-daemon's new `/lite`** — fell through to a raw JSON `{error:'Unauthorized'}` 401 on a fresh (no-cookie) device, instead of the form. Since core is the **contract for downstream variants**, it shouldn't have to enumerate their page paths.

### Change
Replace the path list with a content-negotiation check:
```ts
if (c.req.method === 'GET' && (c.req.header('Accept') ?? '').includes('text/html')) {
  return c.html(loginPage(), 401);
}
return c.json({ error: 'Unauthorized' }, 401);
```
- Browser **top-level navigations** send `Accept: text/html` → they get the login form (covers `/chat`, `/overworld`, `/console`, `/lite`, and any future page in any variant).
- **fetch/API** requests (`Accept: */*` or `application/json`) → JSON 401, unchanged.

### Tests
`makeContext` gains an `Accept` override. The `/chat` test now simulates a real browser nav (`Accept: text/html`); added `/lite`-with-`Accept` → form and `/api/agenda` fetch (`Accept: */*`) → JSON. **18/18 pass**, typecheck clean.

### Downstream
aegis-daemon consumes core via the local path dep, so the daemon picks this up on its next build/deploy — fixing the fresh-device login form on `/lite` (Stackbilt-dev/aegis#631).

### Note (out of scope, flagging)
Live core auth compares `token !== env.AEGIS_TOKEN` directly (not constant-time). Bearer-over-HTTPS makes timing attacks impractical, but a `timingSafeEqual` would be defense-in-depth — happy to follow up separately.
