### PR TITLE
[codex] harden digest delivery and grounding dispatch

### DIFF
--- a/web/src/kernel/dispatch.ts
+++ b/web/src/kernel/dispatch.ts
@@ -1,12 +1,20 @@
 import { route } from './router.js';
 import { recordEpisode, retrogradeEpisode, upsertProcedure, addRefinement, degradeProcedure, getProcedure, procedureKey } from './memory/index.js';
-import { searchMemoryByKeywords, getAllMemoryForContext } from './memory-adapter.js';
+import { getAllMemoryForContext } from './memory-adapter.js';
 import { generateBriefing, formatBriefing } from './briefing.js';
-import { fetchRelevantInsights } from './insight-cache.js';
 import { probeConsistency } from '../groq.js';
 import { executeComposite } from '../composite.js';
 import { buildGroqSystemPrompt } from '../operator/prompt-builder.js';
 import type { KernelIntent, DispatchResult, Executor } from './types.js';
+import type { GroundingEnvelope } from './grounding/fanout.js';
+import {
+  augmentWithEntityGrounding,
+  augmentWithInsights,
+  augmentWithMemoryRecall,
+  applyFabricationCheck,
+  applyGapSignal,
+  applyGroundingProof,
+} from './grounding-layer.js';
 import {
   executeGptOss,
   executeClaudeStream,
@@ -156,6 +164,7 @@ interface AugmentedContext {
   classification: string;
   procKey: string;
   existingProcedure: Awaited<ReturnType<typeof getProcedure>>;
+  grounding?: GroundingEnvelope;
 }
 
 async function augmentIntent(intent: KernelIntent, env: EdgeEnv): Promise<AugmentedContext> {
@@ -165,34 +174,11 @@ async function augmentIntent(intent: KernelIntent, env: EdgeEnv): Promise<Augmen
   const procKey = procedureKey(classification, intent.complexity);
   const existingProcedure = await getProcedure(env.db, procKey);
 
-  // 1.3. Cross-repo insight augmentation (CRIX #106)
-  if (env.memoryBinding && classification !== 'greeting' && classification !== 'heartbeat') {
-    try {
-      const insightContext = await fetchRelevantInsights(env, classification, intent.raw);
-      if (insightContext) {
-        intent.raw = `${insightContext}\n\n${intent.raw}`;
-      }
-    } catch (err) {
-      console.warn('[dispatch] Insight fetch failed (non-fatal):', err instanceof Error ? err.message : String(err));
-    }
-  }
-
-  // 1.5. Memory-recall augmentation
-  if (classification === 'memory_recall') {
-    try {
-      if (env.memoryBinding) {
-        const relevant = await searchMemoryByKeywords(env.memoryBinding, intent.raw, 10);
-        if (relevant.length > 0) {
-          const memLines = relevant.map(m => `- [${m.topic}] ${m.fact} (confidence: ${m.confidence})`).join('\n');
-          intent.raw = `[Relevant memory entries matching this query]\n${memLines}\n\n[User's question]\n${intent.raw}`;
-        }
-      } else {
-        console.warn('[dispatch] Memory binding unavailable — skipping memory recall augmentation');
-      }
-    } catch (err) {
-      console.warn('[dispatch] Memory search failed (non-fatal):', err instanceof Error ? err.message : String(err));
-    }
-  }
+  // 1.3-1.5. Grounding-layer augmentations: cross-repo insights, entity
+  // grounding, and memory recall. Each helper is non-fatal by contract.
+  await augmentWithInsights(intent, classification, env);
+  const grounding = await augmentWithEntityGrounding(intent, classification, env);
+  await augmentWithMemoryRecall(intent, classification, env);
 
   // 1.6. Implicit feedback — retrograde previous episode on user correction
   if (classification === 'user_correction' && intent.source.threadId) {
@@ -221,7 +207,7 @@ async function augmentIntent(intent: KernelIntent, env: EdgeEnv): Promise<Augmen
     }
   }
 
-  return { plan, nearMiss, reclassified, classification, procKey, existingProcedure };
+  return { plan, nearMiss, reclassified, classification, procKey, existingProcedure, grounding };
 }
 
 // ─── Self-Improvement ACK ────────────────────────────────────
@@ -275,7 +261,6 @@ interface ExecuteResult {
   meta?: unknown;
   outcome: 'success' | 'failure' | 'partial_failure';
   probeResult?: 'agreed' | 'split' | 'escalated';
-  earlyReturn?: DispatchResult; // probe agreed → skip executor
 }
 
 async function probeAndExecute(
@@ -302,11 +287,8 @@ async function probeAndExecute(
         probeResult = 'agreed';
         plan.executor = 'groq';
         if (onDelta) onDelta(text);
-        const latencyMs = Date.now() - startMs;
-        await recordOutcome(env, intent, classification, procKey, plan, existingProcedure, text, cost, latencyMs, nearMiss, 'success', ctx.reclassified);
         return {
           text, cost, outcome: 'success', probeResult,
-          earlyReturn: { text, executor: plan.executor, cost, latency_ms: latencyMs, procedureHit: !!plan.procedureId, classification, confidence: intent.confidence, reclassified: ctx.reclassified, probeResult, meta: undefined },
         };
       } else if (probe.sigma === 1.0) {
         const prev = plan.executor;
@@ -489,7 +471,7 @@ function buildResult(
   exec: ExecuteResult,
   latencyMs: number,
 ): DispatchResult {
-  return {
+  const result: DispatchResult = {
     text: exec.text,
     executor: ctx.plan.executor,
     cost: exec.cost,
@@ -501,6 +483,26 @@ function buildResult(
     probeResult: exec.probeResult,
     meta: exec.meta,
   };
+  if (ctx.grounding) {
+    result.grounded = ctx.grounding.grounded;
+    result.sources = ctx.grounding.sources;
+    result.unknowns = ctx.grounding.unknowns;
+    result.searched = ctx.grounding.searched;
+  }
+  return result;
+}
+
+async function finalizeGrounding(
+  ctx: AugmentedContext,
+  intent: KernelIntent,
+  env: EdgeEnv,
+  exec: ExecuteResult,
+  latencyMs: number,
+): Promise<{ result: DispatchResult; outcome: 'success' | 'failure' | 'partial_failure' }> {
+  const result = buildResult(ctx, intent, exec, latencyMs);
+  await applyFabricationCheck(result, exec.text, env);
+  const outcome = applyGroundingProof(exec.outcome, ctx.classification, result);
+  return { result, outcome };
 }
 
 // ─── Main Dispatch Loop ──────────────────────────────────────
@@ -514,10 +516,10 @@ export async function dispatch(intent: KernelIntent, env: EdgeEnv): Promise<Disp
   if (ack) return ack;
 
   const exec = await probeAndExecute(ctx, intent, env, startMs);
-  if (exec.earlyReturn) return exec.earlyReturn;
-
   const latencyMs = Date.now() - startMs;
-  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, exec.outcome, ctx.reclassified);
+  const { result, outcome } = await finalizeGrounding(ctx, intent, env, exec, latencyMs);
+  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, outcome, ctx.reclassified);
+  await applyGapSignal(result, ctx.procKey, ctx.classification, env);
 
   // Background: shadow exploration + shadow read
   if (env.ctx) {
@@ -533,7 +535,7 @@ export async function dispatch(intent: KernelIntent, env: EdgeEnv): Promise<Disp
     }
   }
 
-  return buildResult(ctx, intent, exec, latencyMs);
+  return result;
 }
 
 // ─── Streaming Dispatch ──────────────────────────────────────
@@ -547,10 +549,10 @@ export async function dispatchStream(
   const ctx = await augmentIntent(intent, env);
 
   const exec = await probeAndExecute(ctx, intent, env, startMs, onDelta);
-  if (exec.earlyReturn) return exec.earlyReturn;
-
   const latencyMs = Date.now() - startMs;
-  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, exec.outcome, ctx.reclassified);
+  const { result, outcome } = await finalizeGrounding(ctx, intent, env, exec, latencyMs);
+  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, outcome, ctx.reclassified);
+  await applyGapSignal(result, ctx.procKey, ctx.classification, env);
 
   // Background: shadow exploration + shadow read
   if (env.ctx) {
@@ -566,5 +568,5 @@ export async function dispatchStream(
     }
   }
 
-  return buildResult(ctx, intent, exec, latencyMs);
+  return result;
 }

--- a/web/src/kernel/scheduled/digest.ts
+++ b/web/src/kernel/scheduled/digest.ts
@@ -17,9 +17,11 @@ import {
 // Operator log runs at 08:00 UTC to generate content before this fires.
 
 export async function runDailyDigest(env: EdgeEnv): Promise<void> {
-  // Time gate: fire at 09:00 UTC (4:00 AM CT)
+  // Time gate: fire at or after 09:00 UTC (4:00 AM CT).
+  // The 22h cooldown below prevents double-sends, while allowing same-day
+  // catch-up after a transient 09:00 send failure.
   const now = new Date();
-  if (now.getUTCHours() !== 9) return;
+  if (now.getUTCHours() < 9) return;
 
   // Cooldown: 22 hours since last digest
   const lastDigest = await env.db.prepare(
@@ -253,7 +255,7 @@ export async function runDailyDigest(env: EdgeEnv): Promise<void> {
   }
 
   // ── Send digest email ──
-  await sendDailyDigest(
+  await sendDailyDigestWithRetry(
     { resendApiKey: env.resendApiKey, resendApiKeyPersonal: env.resendApiKeyPersonal },
     sections,
     env.notifyEmail,
@@ -270,6 +272,31 @@ export async function runDailyDigest(env: EdgeEnv): Promise<void> {
   ).run();
 
   console.log(`[digest] Daily digest sent: ${sections.completedTasks.length} completed, ${sections.failedTasks.length} failed, ${sections.proposedTasks.length} proposed, ${sections.healthChecks.length} health checks`);
+}
+
+export async function sendDailyDigestWithRetry(
+  apiKeys: { resendApiKey: string; resendApiKeyPersonal: string },
+  sections: DigestSections,
+  notifyEmail?: string,
+  delaysMs: number[] = [1_000, 5_000],
+): Promise<void> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      await sendDailyDigest(apiKeys, sections, notifyEmail);
+      return;
+    } catch (err) {
+      if (attempt >= delaysMs.length) throw err;
+      const delayMs = delaysMs[attempt];
+      attempt += 1;
+      console.warn(
+        `[digest] Daily digest send failed; retrying in ${delayMs}ms ` +
+        `(attempt ${attempt + 1}/${delaysMs.length + 1}):`,
+        err instanceof Error ? err.message : String(err),
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
 }
 
 // ─── Health Check Deduplication (#309) ──────────────────────

--- a/web/tests/digest.test.ts
+++ b/web/tests/digest.test.ts
@@ -1,0 +1,187 @@
+// Daily digest scheduling and delivery resilience tests.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const emailMocks = vi.hoisted(() => ({
+  sendDailyDigest: vi.fn(),
+}));
+
+vi.mock('../src/email.js', () => ({
+  sendDailyDigest: emailMocks.sendDailyDigest,
+}));
+
+vi.mock('../src/operator/index.js', () => ({
+  operatorConfig: {
+    integrations: {
+      bizops: { fallbackUrl: 'http://localhost' },
+    },
+  },
+}));
+
+import { runDailyDigest, sendDailyDigestWithRetry } from '../src/kernel/scheduled/digest.js';
+
+interface MockQuery {
+  sql: string;
+  bindings: unknown[];
+}
+
+function createMockDb(options?: {
+  firstResults?: (Record<string, unknown> | null)[];
+  allResults?: Record<string, unknown>[][];
+}) {
+  const queries: MockQuery[] = [];
+  let firstIdx = 0;
+  let allIdx = 0;
+
+  const db = {
+    prepare(sql: string) {
+      const entry: MockQuery = { sql, bindings: [] };
+      queries.push(entry);
+      return {
+        bind(...args: unknown[]) {
+          entry.bindings = args;
+          return this;
+        },
+        async first<T>(): Promise<T | null> {
+          return (options?.firstResults?.[firstIdx++] ?? null) as T | null;
+        },
+        async all<T>(): Promise<{ results: T[] }> {
+          return { results: (options?.allResults?.[allIdx++] ?? []) as T[] };
+        },
+        async run() {
+          return { success: true, meta: { changes: 1 } };
+        },
+      };
+    },
+    _queries: queries,
+  };
+
+  return db as unknown as D1Database & { _queries: MockQuery[] };
+}
+
+function createDigestDb(lastDigest: { received_at: string } | null = null) {
+  return createMockDb({
+    firstResults: [
+      lastDigest,
+      null, // latest operator_log content
+    ],
+    allResults: [
+      [
+        {
+          payload: JSON.stringify({
+            severity: 'medium',
+            timestamp: '2026-06-01T09:00:00.000Z',
+            checks: [{ name: 'resend_timeout', status: 'warn', detail: 'retry preserved content' }],
+          }),
+        },
+      ],
+      [], // event notifications
+      [], // memory reflection
+      [], // cognitive metrics
+      [], // analytics
+      [], // developer activity
+      [], // service alerts
+      [], // completed tasks
+      [], // failed tasks
+      [], // proposed tasks
+      [], // active agenda
+    ],
+  });
+}
+
+function createEnv(db: D1Database) {
+  return {
+    db,
+    resendApiKey: 'rk_test',
+    resendApiKeyPersonal: 'rk_personal',
+    notifyEmail: 'operator@example.com',
+    bizopsToken: '',
+    bizopsFetcher: undefined,
+  } as any;
+}
+
+describe('runDailyDigest', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    emailMocks.sendDailyDigest.mockReset();
+    emailMocks.sendDailyDigest.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not run before 09:00 UTC', async () => {
+    vi.setSystemTime(new Date('2026-06-01T08:59:00.000Z'));
+    const db = createDigestDb();
+
+    await runDailyDigest(createEnv(db));
+
+    expect(db._queries).toHaveLength(0);
+    expect(emailMocks.sendDailyDigest).not.toHaveBeenCalled();
+  });
+
+  it('runs after 09:00 UTC when no successful digest watermark exists', async () => {
+    vi.setSystemTime(new Date('2026-06-01T10:00:00.000Z'));
+    const db = createDigestDb();
+
+    await runDailyDigest(createEnv(db));
+
+    expect(emailMocks.sendDailyDigest).toHaveBeenCalledTimes(1);
+    expect(db._queries.some(q => q.sql.includes('UPDATE digest_sections SET consumed = 1'))).toBe(true);
+    expect(db._queries.some(q => q.sql.includes("event_id, received_at) VALUES ('daily_digest'"))).toBe(true);
+  });
+
+  it('respects the existing 22 hour cooldown during catch-up hours', async () => {
+    vi.setSystemTime(new Date('2026-06-01T10:00:00.000Z'));
+    const db = createDigestDb({ received_at: '2026-06-01T09:00:00' });
+
+    await runDailyDigest(createEnv(db));
+
+    expect(emailMocks.sendDailyDigest).not.toHaveBeenCalled();
+    expect(db._queries).toHaveLength(1);
+  });
+});
+
+describe('sendDailyDigestWithRetry', () => {
+  beforeEach(() => {
+    emailMocks.sendDailyDigest.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('retries transient send failures before succeeding', async () => {
+    emailMocks.sendDailyDigest
+      .mockRejectedValueOnce(new Error('Resend API request timed out after 10s'))
+      .mockRejectedValueOnce(new Error('Resend API request timed out after 10s'))
+      .mockResolvedValueOnce(undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await sendDailyDigestWithRetry(
+      { resendApiKey: 'rk_test', resendApiKeyPersonal: 'rk_personal' },
+      {
+        completedTasks: [],
+        failedTasks: [],
+        proposedTasks: [],
+        operatorLog: null,
+        healthChecks: [],
+        eventNotifications: [],
+        memoryReflection: null,
+        cognitiveMetrics: null,
+        analytics: null,
+        devActivity: null,
+        serviceAlerts: [],
+        agendaItems: [],
+        bizopsInteractions: null,
+      },
+      'operator@example.com',
+      [0, 0],
+    );
+
+    expect(emailMocks.sendDailyDigest).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/tests/dispatch.test.ts
+++ b/web/tests/dispatch.test.ts
@@ -110,6 +110,15 @@ vi.mock('../src/kernel/memory-adapter.js', () => ({
   getAllMemoryForContext: vi.fn().mockResolvedValue({ text: '', ids: [] }),
 }));
 
+vi.mock('../src/kernel/grounding-layer.js', () => ({
+  augmentWithInsights: vi.fn().mockResolvedValue(undefined),
+  augmentWithEntityGrounding: vi.fn().mockResolvedValue(undefined),
+  augmentWithMemoryRecall: vi.fn().mockResolvedValue(undefined),
+  applyFabricationCheck: vi.fn().mockResolvedValue(undefined),
+  applyGapSignal: vi.fn().mockResolvedValue(undefined),
+  applyGroundingProof: vi.fn((outcome: 'success' | 'failure' | 'partial_failure') => outcome),
+}));
+
 // Mock groq (probeConsistency)
 vi.mock('../src/groq.js', () => ({
   probeConsistency: vi.fn().mockResolvedValue({ sigma: 0.5, agreedText: null }),
@@ -153,10 +162,17 @@ vi.mock('../src/kernel/executors/index.js', () => {
 const { createIntent, dispatch, dispatchStream } = await import('../src/kernel/dispatch.js');
 const { route } = await import('../src/kernel/router.js');
 const { recordEpisode, upsertProcedure, retrogradeEpisode, degradeProcedure, getProcedure } = await import('../src/kernel/memory/index.js');
-const { searchMemoryByKeywords } = await import('../src/kernel/memory-adapter.js');
 const { probeConsistency } = await import('../src/groq.js');
 const { executeGptOss, executeGroq, executeDirect, executeWorkersAi, executeCodeTask, executeWithAnthropicFailover, executeClaudeStream } = await import('../src/kernel/executors/index.js');
 const { executeComposite } = await import('../src/composite.js');
+const {
+  augmentWithInsights,
+  augmentWithEntityGrounding,
+  augmentWithMemoryRecall,
+  applyFabricationCheck,
+  applyGapSignal,
+  applyGroundingProof,
+} = await import('../src/kernel/grounding-layer.js');
 
 function makeEdgeEnv(overrides: Partial<EdgeEnv> = {}): EdgeEnv {
   return {
@@ -442,27 +458,28 @@ describe('dispatch — memory recall augmentation', () => {
     vi.mocked(getProcedure).mockResolvedValue(null);
   });
 
-  it('augments intent with memory entries for memory_recall classification', async () => {
+  it('delegates memory_recall augmentation to the grounding layer', async () => {
     setupRoute('gpt_oss', 'memory_recall');
-    vi.mocked(searchMemoryByKeywords).mockResolvedValue([
-      { id: '1', topic: 'test', fact: 'test fact', confidence: 0.9 },
-    ]);
+    vi.mocked(augmentWithMemoryRecall).mockImplementationOnce(async (intent) => {
+      intent.raw = `[Relevant wiki pages matching this query]\n- test fact\n\n[User's question]\n${intent.raw}`;
+    });
 
     const intent = createIntent('t', 'what do you remember about X');
-    const env = makeEdgeEnv({ memoryBinding: { recall: vi.fn(), store: vi.fn(), forget: vi.fn(), decay: vi.fn(), consolidate: vi.fn(), health: vi.fn(), stats: vi.fn() } as any });
-    await dispatch(intent, env);
+    await dispatch(intent, makeEdgeEnv());
 
-    expect(searchMemoryByKeywords).toHaveBeenCalled();
-    expect(intent.raw).toContain('Relevant memory entries');
+    expect(augmentWithMemoryRecall).toHaveBeenCalledWith(intent, 'memory_recall', expect.anything());
+    expect(intent.raw).toContain('Relevant wiki pages');
   });
 
-  it('memory recall augmentation failure is non-fatal', async () => {
+  it('skips memory_recall mutation when the grounding layer has no hits', async () => {
     setupRoute('gpt_oss', 'memory_recall');
-    vi.mocked(searchMemoryByKeywords).mockRejectedValue(new Error('memory down'));
+    const intent = createIntent('t', 'recall');
 
-    const env = makeEdgeEnv({ memoryBinding: {} as any });
-    const result = await dispatch(createIntent('t', 'recall'), env);
-    expect(result).toBeDefined(); // should not throw
+    const result = await dispatch(intent, makeEdgeEnv());
+
+    expect(augmentWithMemoryRecall).toHaveBeenCalled();
+    expect(result).toBeDefined();
+    expect(intent.raw).toBe('recall');
   });
 });
 
@@ -761,6 +778,67 @@ describe('dispatch — result shape', () => {
   });
 });
 
+describe('dispatch — grounding layer integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getProcedure).mockResolvedValue(null);
+  });
+
+  it('includes grounding envelope fields returned by entity grounding', async () => {
+    setupRoute('gpt_oss', 'bizops_read');
+    vi.mocked(augmentWithEntityGrounding).mockResolvedValueOnce({
+      grounded: true,
+      sources: ['d1:agenda/12'],
+      unknowns: [],
+      searched: ['d1.agenda'],
+    });
+
+    const result = await dispatch(createIntent('t', 'what is #12?'), makeEdgeEnv());
+
+    expect(result.grounded).toBe(true);
+    expect(result.sources).toEqual(['d1:agenda/12']);
+    expect(result.unknowns).toEqual([]);
+    expect(result.searched).toEqual(['d1.agenda']);
+  });
+
+  it('runs fabrication check before recording the grounded outcome', async () => {
+    setupRoute('gpt_oss', 'bizops_read');
+    vi.mocked(applyFabricationCheck).mockImplementationOnce(async (result) => {
+      result.grounded = false;
+      result.unverified_claims = ['unverified task mutation'];
+    });
+    vi.mocked(applyGroundingProof).mockReturnValueOnce('partial_failure');
+
+    await dispatch(createIntent('t', 'show #12'), makeEdgeEnv());
+
+    expect(applyFabricationCheck).toHaveBeenCalled();
+    expect(applyGroundingProof).toHaveBeenCalledWith(
+      'success',
+      'bizops_read',
+      expect.objectContaining({ unverified_claims: ['unverified task mutation'] }),
+    );
+    expect(recordEpisode).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ outcome: 'failure' }),
+    );
+    expect(upsertProcedure).toHaveBeenCalledWith(
+      expect.anything(),
+      'bizops_read:mid',
+      expect.anything(),
+      expect.anything(),
+      'partial_failure',
+      expect.any(Number),
+      expect.any(Number),
+    );
+    expect(applyGapSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ unverified_claims: ['unverified task mutation'] }),
+      'bizops_read:mid',
+      'bizops_read',
+      expect.anything(),
+    );
+  });
+});
+
 // ── Insight injection tests ─────────────────────────────────
 
 describe('dispatch — CRIX insight injection', () => {
@@ -771,94 +849,43 @@ describe('dispatch — CRIX insight injection', () => {
     // We rely on memoryBinding.recall being freshly mocked each test
   });
 
-  it('injects relevant insights into intent.raw when memoryBinding available', async () => {
+  it('delegates insight injection to the grounding layer', async () => {
     setupRoute('gpt_oss', 'general_knowledge');
-    const mockRecall = vi.fn().mockResolvedValue([
-      { content: '[pattern] (from demo-app) Deploy using wrangler deploy command' },
-      { content: '[antipattern] (from img-forge) Never use direct D1 access from frontend' },
-    ]);
-
+    vi.mocked(augmentWithInsights).mockImplementationOnce(async (intent) => {
+      intent.raw = `[Cross-Repo Intelligence]\n- Deploy using wrangler deploy command\n\n${intent.raw}`;
+    });
     const intent = createIntent('t', 'how do I deploy using wrangler');
-    const env = makeEdgeEnv({
-      memoryBinding: {
-        recall: mockRecall,
-        store: vi.fn(),
-        forget: vi.fn(),
-        decay: vi.fn(),
-        consolidate: vi.fn(),
-        health: vi.fn(),
-        stats: vi.fn(),
-      } as any,
-    });
 
-    await dispatch(intent, env);
+    await dispatch(intent, makeEdgeEnv());
 
-    // The recall should have been called for insights
-    expect(mockRecall).toHaveBeenCalledWith('aegis', expect.objectContaining({
-      topic: 'cross_repo_insights',
-    }));
+    expect(augmentWithInsights).toHaveBeenCalledWith(intent, 'general_knowledge', expect.anything());
+    expect(intent.raw).toContain('Cross-Repo Intelligence');
   });
 
-  it('skips insight injection for greeting classification', async () => {
+  it('delegates greeting insight skip decisions to the grounding layer', async () => {
     setupRoute('groq', 'greeting');
-    const mockRecall = vi.fn().mockResolvedValue([]);
 
-    const env = makeEdgeEnv({
-      memoryBinding: {
-        recall: mockRecall,
-        store: vi.fn(),
-        forget: vi.fn(),
-        decay: vi.fn(),
-        consolidate: vi.fn(),
-        health: vi.fn(),
-        stats: vi.fn(),
-      } as any,
-    });
+    const intent = createIntent('t', 'hello');
+    await dispatch(intent, makeEdgeEnv());
 
-    await dispatch(createIntent('t', 'hello'), env);
-
-    // Should NOT call recall for greeting/heartbeat
-    expect(mockRecall).not.toHaveBeenCalled();
+    expect(augmentWithInsights).toHaveBeenCalledWith(intent, 'greeting', expect.anything());
   });
 
-  it('skips insight injection for heartbeat classification', async () => {
+  it('delegates heartbeat insight skip decisions to the grounding layer', async () => {
     setupRoute('direct', 'heartbeat');
-    const mockRecall = vi.fn().mockResolvedValue([]);
 
-    const env = makeEdgeEnv({
-      memoryBinding: {
-        recall: mockRecall,
-        store: vi.fn(),
-        forget: vi.fn(),
-        decay: vi.fn(),
-        consolidate: vi.fn(),
-        health: vi.fn(),
-        stats: vi.fn(),
-      } as any,
-    });
+    const intent = createIntent('t', 'heartbeat');
+    await dispatch(intent, makeEdgeEnv());
 
-    await dispatch(createIntent('t', 'heartbeat'), env);
-    expect(mockRecall).not.toHaveBeenCalled();
+    expect(augmentWithInsights).toHaveBeenCalledWith(intent, 'heartbeat', expect.anything());
   });
 
-  it('insight fetch failure is non-fatal', async () => {
+  it('runs normally when the grounding layer leaves the query unchanged', async () => {
     setupRoute('gpt_oss', 'general_knowledge');
     vi.mocked(executeGptOss).mockResolvedValue({ text: 'gpt_oss result', cost: 0.005 });
-    const mockRecall = vi.fn().mockRejectedValue(new Error('memory worker down'));
 
-    const env = makeEdgeEnv({
-      memoryBinding: {
-        recall: mockRecall,
-        store: vi.fn(),
-        forget: vi.fn(),
-        decay: vi.fn(),
-        consolidate: vi.fn(),
-        health: vi.fn(),
-        stats: vi.fn(),
-      } as any,
-    });
+    const result = await dispatch(createIntent('t', 'test query'), makeEdgeEnv());
 
-    const result = await dispatch(createIntent('t', 'test query'), env);
     expect(result).toBeDefined();
     expect(result.text).toBe('gpt_oss result');
   });


### PR DESCRIPTION
## Summary

Fixes the daily digest same-day drop path from #49 and wires the existing grounding-layer primitives into the dispatch loop for #34.

## What Changed

- Daily digest now skips only before 09:00 UTC, then relies on the existing 22h watermark cooldown to prevent duplicate sends.
- Daily digest delivery now retries Resend sends twice with backoff before failing.
- Dispatch now delegates insight injection, entity grounding, and memory recall augmentation to `grounding-layer`.
- Dispatch result envelopes now include grounding fields when entity grounding has evidence.
- Fabrication checks now run before procedural-memory outcome recording.
- Grounding proof can downgrade a successful grounding-gated response to `partial_failure` before `recordEpisode` and `upsertProcedure` learn from it.
- Gap-signal bookkeeping now runs after the procedure row is recorded.
- Probe-agreed responses now go through the same finalization path instead of bypassing grounding checks.

## Impact

The digest no longer drops a fully assembled brief after one transient Resend timeout. Grounding-gated dispatches also stop teaching procedural memory from fabricated or unverified successful-looking responses.

## Validation

- `npx vitest run tests/digest.test.ts`
- `npx vitest run tests/digest.test.ts tests/email.test.ts tests/scheduled.test.ts tests/scheduled-orchestration.test.ts`
- `npx vitest run tests/provider-factory.test.ts tests/observability.test.ts`
- `npx vitest run tests/dispatch.test.ts`
- `npx vitest run tests/dispatch.test.ts tests/router.test.ts tests/memory/procedural.test.ts tests/memory-service.test.ts`
- `npm run typecheck`
- `npm test` (69 files, 1501 passed, 1 skipped)

## Issues

- Fixes #49
- Advances #34
