### PR TITLE
[codex] persist grounding gaps on episodes

### DIFF
--- a/web/schema.sql
+++ b/web/schema.sql
@@ -67,6 +67,7 @@ CREATE TABLE IF NOT EXISTS episodic_memory (
   executor TEXT,                               -- which executor handled this
   complexity_tier TEXT,                        -- aegis#563: procedureKey complement (low|mid|high); NULL for non-dispatcher producers
   executor_config TEXT,                        -- aegis#563: config snapshot at emit time (evaluator-replay fidelity)
+  grounding_gap INTEGER NOT NULL DEFAULT 0,     -- aegis#497/#34: unresolved grounding gap observed on this episode
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -208,6 +209,7 @@ CREATE INDEX IF NOT EXISTS idx_episodic_class ON episodic_memory(intent_class);
 CREATE INDEX IF NOT EXISTS idx_episodic_created ON episodic_memory(created_at);
 CREATE INDEX IF NOT EXISTS idx_episodic_thread ON episodic_memory(thread_id);
 CREATE INDEX IF NOT EXISTS idx_episodic_class_complexity ON episodic_memory(intent_class, complexity_tier);
+CREATE INDEX IF NOT EXISTS idx_episodic_grounding_gap ON episodic_memory(grounding_gap, created_at);
 CREATE INDEX IF NOT EXISTS idx_procedural_pattern ON procedural_memory(task_pattern);
 CREATE INDEX IF NOT EXISTS idx_procedural_status ON procedural_memory(status);
 CREATE INDEX IF NOT EXISTS idx_heartbeat_created ON heartbeat_results(created_at);

--- a/web/src/kernel/dispatch.ts
+++ b/web/src/kernel/dispatch.ts
@@ -121,6 +121,7 @@ async function recordOutcome(
   latencyMs: number,
   nearMiss: string | null | undefined,
   outcome: 'success' | 'failure' | 'partial_failure',
+  groundingGap: boolean,
   reclassified?: boolean,
 ): Promise<void> {
   await recordEpisode(env.db, {
@@ -135,6 +136,7 @@ async function recordOutcome(
     reclassified,
     thread_id: intent.source.threadId,
     executor: plan.executor,
+    grounding_gap: groundingGap,
   });
 
   await upsertProcedure(env.db, procKey, plan.executor, JSON.stringify({ executor: plan.executor }), outcome, latencyMs, cost);
@@ -498,11 +500,14 @@ async function finalizeGrounding(
   env: EdgeEnv,
   exec: ExecuteResult,
   latencyMs: number,
-): Promise<{ result: DispatchResult; outcome: 'success' | 'failure' | 'partial_failure' }> {
+): Promise<{ result: DispatchResult; outcome: 'success' | 'failure' | 'partial_failure'; groundingGap: boolean }> {
   const result = buildResult(ctx, intent, exec, latencyMs);
   await applyFabricationCheck(result, exec.text, env);
   const outcome = applyGroundingProof(exec.outcome, ctx.classification, result);
-  return { result, outcome };
+  const groundingGap =
+    (result.unverified_claims?.length ?? 0) > 0 ||
+    (result.unknowns?.length ?? 0) > 0;
+  return { result, outcome, groundingGap };
 }
 
 // ─── Main Dispatch Loop ──────────────────────────────────────
@@ -517,8 +522,8 @@ export async function dispatch(intent: KernelIntent, env: EdgeEnv): Promise<Disp
 
   const exec = await probeAndExecute(ctx, intent, env, startMs);
   const latencyMs = Date.now() - startMs;
-  const { result, outcome } = await finalizeGrounding(ctx, intent, env, exec, latencyMs);
-  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, outcome, ctx.reclassified);
+  const { result, outcome, groundingGap } = await finalizeGrounding(ctx, intent, env, exec, latencyMs);
+  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, outcome, groundingGap, ctx.reclassified);
   await applyGapSignal(result, ctx.procKey, ctx.classification, env);
 
   // Background: shadow exploration + shadow read
@@ -550,8 +555,8 @@ export async function dispatchStream(
 
   const exec = await probeAndExecute(ctx, intent, env, startMs, onDelta);
   const latencyMs = Date.now() - startMs;
-  const { result, outcome } = await finalizeGrounding(ctx, intent, env, exec, latencyMs);
-  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, outcome, ctx.reclassified);
+  const { result, outcome, groundingGap } = await finalizeGrounding(ctx, intent, env, exec, latencyMs);
+  await recordOutcome(env, intent, ctx.classification, ctx.procKey, ctx.plan, ctx.existingProcedure, exec.text, exec.cost, latencyMs, ctx.nearMiss, outcome, groundingGap, ctx.reclassified);
   await applyGapSignal(result, ctx.procKey, ctx.classification, env);
 
   // Background: shadow exploration + shadow read

--- a/web/src/kernel/memory/episodic.ts
+++ b/web/src/kernel/memory/episodic.ts
@@ -16,13 +16,15 @@ export function sanitizeEpisodicOutcome(raw: string | null | undefined): Episodi
 
 export async function recordEpisode(db: D1Database, entry: Omit<EpisodicEntry, 'id' | 'created_at'>): Promise<void> {
   const safeOutcome = sanitizeEpisodicOutcome(entry.outcome);
+  const groundingGap = entry.grounding_gap ? 1 : 0;
   await db.prepare(
-    'INSERT INTO episodic_memory (intent_class, channel, summary, outcome, cost, latency_ms, near_miss, classifier_confidence, reclassified, thread_id, executor) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    'INSERT INTO episodic_memory (intent_class, channel, summary, outcome, cost, latency_ms, near_miss, classifier_confidence, reclassified, thread_id, executor, grounding_gap) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
   ).bind(
     entry.intent_class, entry.channel, entry.summary, safeOutcome,
     entry.cost, entry.latency_ms, entry.near_miss ?? null,
     entry.classifier_confidence ?? null, entry.reclassified ? 1 : 0,
     entry.thread_id ?? null, entry.executor ?? null,
+    groundingGap,
   ).run();
 }
 

--- a/web/src/kernel/types.ts
+++ b/web/src/kernel/types.ts
@@ -40,6 +40,7 @@ export interface EpisodicEntry {
   executor?: string | null;
   complexity_tier?: string | null;
   executor_config?: string | null;
+  grounding_gap?: boolean | number;
   created_at?: string;
 }
 

--- a/web/tests/dispatch.test.ts
+++ b/web/tests/dispatch.test.ts
@@ -350,7 +350,7 @@ describe('dispatch — error handling', () => {
     // recordEpisode should be called with outcome 'failure'
     expect(recordEpisode).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ outcome: 'failure' }),
+      expect.objectContaining({ outcome: 'failure', grounding_gap: false }),
     );
   });
 
@@ -536,7 +536,7 @@ describe('dispatch — partial failure detection', () => {
     // partial_failure episodes should be recorded as 'failure'
     expect(recordEpisode).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ outcome: 'failure' }),
+      expect.objectContaining({ outcome: 'failure', grounding_gap: false }),
     );
   });
 });
@@ -819,7 +819,7 @@ describe('dispatch — grounding layer integration', () => {
     );
     expect(recordEpisode).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ outcome: 'failure' }),
+      expect.objectContaining({ outcome: 'failure', grounding_gap: true }),
     );
     expect(upsertProcedure).toHaveBeenCalledWith(
       expect.anything(),

--- a/web/tests/memory/episodic.test.ts
+++ b/web/tests/memory/episodic.test.ts
@@ -98,8 +98,26 @@ describe('recordEpisode', () => {
 
     expect(db._queries).toHaveLength(1);
     expect(db._queries[0].sql).toContain('INSERT INTO episodic_memory');
+    expect(db._queries[0].sql).toContain('grounding_gap');
     expect(db._queries[0].bindings[0]).toBe('greeting');
     expect(db._queries[0].bindings[3]).toBe('success');
+    expect(db._queries[0].bindings[11]).toBe(0);
+  });
+
+  it('persists grounding gap as an integer flag', async () => {
+    const db = createMockDb({ runResults: [{ success: true }] });
+
+    await recordEpisode(db, {
+      intent_class: 'bizops_read',
+      channel: 'web',
+      summary: 'Read had unresolved entity',
+      outcome: 'failure',
+      cost: 0.01,
+      latency_ms: 400,
+      grounding_gap: true,
+    });
+
+    expect(db._queries[0].bindings[11]).toBe(1);
   });
 
   it('sanitizes invalid outcome to failure before insert', async () => {


### PR DESCRIPTION
## Summary

Fixes #34 by completing the remaining grounding-gap persistence path now that the grounding layer is integrated at dispatch.

- adds `episodic_memory.grounding_gap` plus an index for gap-oriented reads
- persists grounding gaps from dispatch when grounded responses contain unknowns or unverified claims
- keeps procedural gap-signal bookkeeping intact while adding episode-level evidence
- adds focused tests for the DB boundary and dispatch grounding downgrade path

## Validation

- `npx vitest run tests/dispatch.test.ts tests/memory/episodic.test.ts tests/memory/procedural.test.ts`
- `npm run typecheck`
- `npm test`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

## Notes

This repo has `web/schema.sql` as the schema source and no separate migrations directory, so the schema change is additive there.
