### PR TITLE
[codex] add disambiguation firewall

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,19 @@ Every user message follows the same path through the kernel:
 
 4. **Learn** — Record the episode: what was asked, which executor handled it, whether it succeeded, how long it took, what it cost. This feeds back into procedural memory over time.
 
+## Disambiguation firewall
+
+AEGIS halts before model routing when a user asks for an internal data or metric concept that is not strictly defined. For example, "what is churn?" is ambiguous unless the user specifies seat count, account count, revenue, MRR, or another basis. The router classifies these requests as `request_clarification` and sends them to the `direct` executor, which returns a zero-cost clarification prompt instead of letting an LLM guess.
+
+Known typed data surfaces, such as compliance deadlines, documents, projects, agenda items, goals, and health checks, continue through normal routing. So do metric requests where the user already names the basis, such as "show churn by MRR for last 30 days."
+
+The pattern for OSS integrations is:
+
+- expose business data through typed MCP tools or strict JSON-schema endpoints
+- keep the schema definitions at the tool boundary, not in free-form model context
+- route undefined data concepts to `request_clarification`
+- only allow LLM executors to analyze data returned by those typed tools
+
 ## Executors
 
 AEGIS supports multiple AI backends, selected per-request based on intent and learned performance:

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "./kernel/dispatch": "./src/kernel/dispatch.ts",
     "./kernel/router": "./src/kernel/router.ts",
     "./kernel/types": "./src/kernel/types.ts",
+    "./kernel/disambiguation": "./src/kernel/disambiguation.ts",
     "./kernel/memory": "./src/kernel/memory/index.ts",
     "./kernel/memory-adapter": "./src/kernel/memory-adapter.ts",
     "./kernel/resilience": "./src/kernel/resilience.ts",

--- a/web/src/kernel/disambiguation.ts
+++ b/web/src/kernel/disambiguation.ts
@@ -1,0 +1,55 @@
+export interface DisambiguationRequest {
+  concept: string;
+  question: string;
+}
+
+const DATA_INTENT =
+  /\b(what|show|calculate|report|compare|analy[sz]e|trend|metric|dashboard|how many|how much|rate)\b/i;
+
+const KNOWN_DATA_SURFACES =
+  /\b(compliance|deadline|deadlines|filing|filings|document|documents|project|projects|agenda|goal|goals|task|tasks|health|heartbeat)\b/i;
+
+const DISAMBIGUATORS =
+  /\b(by|defined as|definition|seat count|seats|mrr|arr|gross|net|monthly|annual|period|last \d+|past \d+|count|rate)\b/i;
+
+const AMBIGUOUS_CONCEPTS: Array<{ name: string; pattern: RegExp; question: string }> = [
+  {
+    name: 'churn',
+    pattern: /\bchurn\b/i,
+    question: 'Do you mean churn by seat count, account count, revenue, MRR, or another defined basis?',
+  },
+  {
+    name: 'retention',
+    pattern: /\bretention\b/i,
+    question: 'Do you mean retention by user, account, seat, revenue, cohort, or another defined basis?',
+  },
+  {
+    name: 'active users',
+    pattern: /\b(active users?|users?)\b/i,
+    question: 'Do you mean active users by login, event activity, paid seat, account membership, or another defined rule?',
+  },
+  {
+    name: 'conversion',
+    pattern: /\b(conversion|activation)\b/i,
+    question: 'Do you mean conversion by visit, signup, qualified lead, paid account, or another funnel step?',
+  },
+  {
+    name: 'revenue',
+    pattern: /\b(revenue|growth)\b/i,
+    question: 'Do you mean revenue by gross, net, MRR, ARR, cash receipts, or another defined basis?',
+  },
+];
+
+export function detectDisambiguationNeed(message: string): DisambiguationRequest | null {
+  if (!DATA_INTENT.test(message)) return null;
+  if (KNOWN_DATA_SURFACES.test(message)) return null;
+  if (DISAMBIGUATORS.test(message)) return null;
+
+  for (const concept of AMBIGUOUS_CONCEPTS) {
+    if (concept.pattern.test(message)) {
+      return { concept: concept.name, question: concept.question };
+    }
+  }
+
+  return null;
+}

--- a/web/src/kernel/executors/direct.ts
+++ b/web/src/kernel/executors/direct.ts
@@ -90,6 +90,20 @@ export async function executeDirect(
   intent: KernelIntent,
   env: EdgeEnv,
 ): Promise<{ text: string; cost: number; meta?: unknown }> {
+  if (intent.classified === 'request_clarification') {
+    const question = intent.disambiguation?.question
+      ?? 'This data concept is ambiguous. Which exact definition should I use?';
+    return {
+      text: question,
+      cost: 0,
+      meta: {
+        clarificationRequired: true,
+        concept: intent.disambiguation?.concept ?? 'unknown',
+        source: 'disambiguation_firewall',
+      },
+    };
+  }
+
   if (intent.classified === 'heartbeat') {
     // Edge heartbeat: call BizOps dashboard + CF infrastructure in parallel, triage with structured JSON
     const mcpClient = new McpClient({

--- a/web/src/kernel/router.ts
+++ b/web/src/kernel/router.ts
@@ -3,6 +3,7 @@ import { askGroq, askGroqWithLogprobs } from '../groq.js';
 import type { KernelIntent, ExecutionPlan, Executor } from './types.js';
 import { buildClassifySystem, getTaskPatterns } from '../operator/prompt-builder.js';
 import { domainPreFilter } from './domain.js';
+import { detectDisambiguationNeed } from './disambiguation.js';
 
 // ─── Confidence Thresholds ──────────────────────────────────
 const CONFIDENCE_TRUST = 0.80;   // ≥ 0.80 → use classification as-is
@@ -94,6 +95,7 @@ async function classifyWithWorkersAI(
 // Fallback routes — used for degraded procedure replanning and when JSON classification fails
 const DEFAULT_ROUTES: Record<string, Executor> = {
   heartbeat: 'direct',
+  request_clarification: 'direct',
   bizops_read: 'gpt_oss',
   bizops_mutate: 'gpt_oss',
   general_knowledge: 'gpt_oss',
@@ -238,6 +240,25 @@ export async function route(
         reasoning: `Internal trigger "${intent.classified}" — no mature procedure, using default`,
         costCeiling: 'free',
       },
+    };
+  }
+
+  // ─── Phase 0.25: Disambiguation firewall ──────────────────
+  const disambiguation = detectDisambiguationNeed(intent.raw);
+  if (disambiguation) {
+    intent.classified = 'request_clarification';
+    intent.complexity = 0;
+    intent.needsTools = false;
+    intent.confidence = 1;
+    intent.disambiguation = disambiguation;
+    return {
+      plan: {
+        executor: 'direct',
+        reasoning: `Disambiguation firewall halted undefined data concept "${disambiguation.concept}"`,
+        costCeiling: 'free',
+      },
+      nearMiss: `disambiguation:${disambiguation.concept}`,
+      reclassified: false,
     };
   }
 

--- a/web/src/kernel/types.ts
+++ b/web/src/kernel/types.ts
@@ -18,6 +18,10 @@ export interface KernelIntent {
   confidence?: number;
   domain?: string;
   domainConfidence?: number;
+  disambiguation?: {
+    concept: string;
+    question: string;
+  };
   timestamp: number;
   costCeiling: 'free' | 'cheap' | 'expensive';
   classifierSource?: 'classify-cast' | 'workers-ai' | 'groq';

--- a/web/src/operator/prompt-builder.ts
+++ b/web/src/operator/prompt-builder.ts
@@ -81,6 +81,7 @@ If conversation context is provided, use it to understand what the user is reall
 
 Categories:
 - heartbeat: Explicitly asking to run a health check, status check, or heartbeat — ONLY when the user directly requests a system diagnostic. NOT for pasting technical data, reporting findings, discussing system state, or asking what needs attention
+- request_clarification: The user asks for an internal data or metric concept whose definition is not strictly specified. Halt and ask which definition to use instead of guessing
 ${bizopsCategories}
 - general_knowledge: General factual questions, conceptual explanations, abstract advice with NO connection to the operator's businesses, projects, or operations
 - memory_recall: Questions about what the agent remembers, past conversations
@@ -100,6 +101,7 @@ Tiebreaker: "roundtable", "generate a roundtable", "show roundtable drafts", "pu
 Tiebreaker: When the user discusses actions to take on their business infrastructure, projects, migrations, deployments, or asks for recommendations tied to business operations → prefer bizops_mutate over general_knowledge. "general_knowledge" is for questions with NO business/operational context (e.g., "what is OAuth?", "explain quantum computing").
 Tiebreaker: When a message reports a bug, error, broken feature, or asks for help using a Stackbilt product → always support_triage, never bizops_read. "bizops_read" is for the operator querying internal business state, not for end-user support requests.
 Tiebreaker: If the user asks "what do you think?" or "what are your thoughts?" in a conversation about business decisions, projects, or operations → bizops_mutate (they want actionable advice + BizOps actions, not a generic essay).
+Disambiguation firewall: If the user asks for data or metrics and the definition is not strictly defined in context, DO NOT GUESS. Use request_clarification. Example: "what is churn?" is ambiguous; ask whether they mean churn by seat count, account count, revenue, MRR, or another defined basis.
 
 Examples:
 - "hi" → {"pattern":"greeting","complexity":0,"needs_tools":false,"confidence":0.99}
@@ -167,6 +169,7 @@ export function getTaskPatterns(): readonly string[] {
 
   const patterns: string[] = [
     'heartbeat',
+    'request_clarification',
     'general_knowledge',
     'memory_recall',
     'greeting',

--- a/web/tests/executors.test.ts
+++ b/web/tests/executors.test.ts
@@ -218,6 +218,24 @@ describe('executeWorkersAi', () => {
 describe('executeDirect', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it('returns a clarification request without LLM cost', async () => {
+    const intent = makeIntent('what is churn?', 'request_clarification');
+    intent.disambiguation = {
+      concept: 'churn',
+      question: 'Do you mean churn by seat count, account count, revenue, MRR, or another defined basis?',
+    };
+
+    const result = await executeDirect(intent, makeEnv());
+
+    expect(result.text).toContain('seat count');
+    expect(result.cost).toBe(0);
+    expect(result.meta).toEqual({
+      clarificationRequired: true,
+      concept: 'churn',
+      source: 'disambiguation_firewall',
+    });
+  });
+
   it('handles heartbeat classification', async () => {
     mockAskGroq.mockResolvedValue('{"actionable":false,"severity":"none","summary":"All systems nominal","checks":[]}');
     const env = makeEnv();

--- a/web/tests/prompt-builder.test.ts
+++ b/web/tests/prompt-builder.test.ts
@@ -197,6 +197,7 @@ describe('getTaskPatterns', () => {
   it('includes base patterns', () => {
     const patterns = getTaskPatterns();
     expect(patterns).toContain('heartbeat');
+    expect(patterns).toContain('request_clarification');
     expect(patterns).toContain('general_knowledge');
     expect(patterns).toContain('greeting');
     expect(patterns).toContain('code_task');

--- a/web/tests/router.test.ts
+++ b/web/tests/router.test.ts
@@ -90,6 +90,44 @@ describe('Router', () => {
   // ── Basic classification + routing ─────────────────────────
 
   describe('classification parsing', () => {
+    it('halts ambiguous data concepts before LLM classification', async () => {
+      const intent = makeIntent('what is churn?');
+      const { plan, nearMiss } = await route(intent, mockDb, 'fake-key', 'fake-model');
+
+      expect(intent.classified).toBe('request_clarification');
+      expect(intent.disambiguation).toEqual(expect.objectContaining({
+        concept: 'churn',
+      }));
+      expect(plan.executor).toBe('direct');
+      expect(plan.costCeiling).toBe('free');
+      expect(plan.reasoning).toContain('Disambiguation firewall');
+      expect(nearMiss).toBe('disambiguation:churn');
+      expect(mockAskGroq).not.toHaveBeenCalled();
+      expect(getProcedure).not.toHaveBeenCalled();
+    });
+
+    it('does not halt known typed data surfaces', async () => {
+      mockAskGroq.mockResolvedValue(jsonClass('bizops_read', 1, true, 0.95));
+
+      const intent = makeIntent('what compliance deadlines are coming up?');
+      const { plan } = await route(intent, mockDb, 'fake-key', 'fake-model');
+
+      expect(intent.classified).toBe('bizops_read');
+      expect(plan.executor).toBe('gpt_oss');
+      expect(mockAskGroq).toHaveBeenCalled();
+    });
+
+    it('does not halt when the user defines the metric basis', async () => {
+      mockAskGroq.mockResolvedValue(jsonClass('bizops_read', 1, true, 0.95));
+
+      const intent = makeIntent('show churn by MRR for last 30 days');
+      const { plan } = await route(intent, mockDb, 'fake-key', 'fake-model');
+
+      expect(intent.classified).toBe('bizops_read');
+      expect(plan.executor).toBe('gpt_oss');
+      expect(mockAskGroq).toHaveBeenCalled();
+    });
+
     it('parses JSON classification and routes greeting to groq', async () => {
       mockAskGroq.mockResolvedValue(jsonClass('greeting', 0, false, 0.99));
 


### PR DESCRIPTION
## Summary

Fixes #4 by adding a generic disambiguation firewall before model routing.

- adds `request_clarification` as a core routing pattern
- detects ambiguous data and metric concepts before LLM classification
- routes those requests to the `direct` executor with a zero-cost clarification response
- exports the detector as `./kernel/disambiguation`
- documents the typed-tool boundary pattern in `docs/architecture.md`

## Validation

- `npx vitest run tests/router.test.ts tests/executors.test.ts tests/prompt-builder.test.ts`
- `npm run typecheck`
- `npm test`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- `npx charter validate --ci --format text`
