### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.7.0 (2026-06-02)
+
+### Added
+- `cli/aegis.mjs` and the `aegis` package binary, including quick-start connection handling and executor override support for terminal demos. (aegis-oss#55)
+- `/chat/ws`, `ChatSession`, and `ChatSessionAuth` primitives for websocket-backed chat sessions, plus schema/configuration docs and tests. (aegis-oss#55)
+- Standalone chat shell UI support and a disambiguation firewall for safer routing and demo-path trust hardening.
+
+### Changed
+- Migrated the remaining in-repo LLM inference paths through `@stackbilt/llm-providers`: Claude executor, dynamic tools, Groq helpers, Workers AI helper fallbacks, composite execution, and the last raw Groq logprobs path. (aegis-oss#24)
+- Hardened digest delivery, grounding dispatch, and grounding-gap persistence so failed or missing evidence is recorded more consistently.
+
+### Fixed
+- Restored the release workflow's npm publish auth fallback while preserving trusted publishing support. (aegis-oss#51)
+
 ## 0.6.5 (2026-06-02)
 
 ### Fixed

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -7,8 +7,8 @@
 Push a semver tag from `main`:
 
 ```bash
-git tag v0.6.6
-git push origin v0.6.6
+git tag v0.7.0
+git push origin v0.7.0
 ```
 
 The workflow installs dependencies, runs typecheck/tests, then publishes `web/package.json` to npm.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stackbilt/aegis-core",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stackbilt/aegis-core",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudflare/voice": "^0.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackbilt/aegis-core",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Persistent AI agent framework for Cloudflare Workers. Multi-tier memory, autonomous goals, dreaming cycles, MCP native.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/web/src/version.ts
+++ b/web/src/version.ts
@@ -1,3 +1,3 @@
-// Semantic version — bump on each deploy
+// Semantic version - bump on each deploy
 // Used in /health endpoint and changelog tracking
-export const VERSION = '0.1.0';
+export const VERSION = '0.7.0';


### PR DESCRIPTION
## Summary
- bump @stackbilt/aegis-core to 0.7.0
- align package lock and exported VERSION
- add 0.7.0 changelog notes and update publishing tag example

## Validation
- npm run typecheck
- npm test
- npm pack --dry-run
- npx charter validate
- git diff --check